### PR TITLE
`Team Workspace Link` 데이터 연동, 스터디 종료 버튼 클릭 시 팀 삭제 반영

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,7 +80,7 @@ function App() {
               {user && user !== 'null' ? <Redirect to="/home" /> : <LoginPage />}
             </Route>
             <Route path="/home">{user && user !== 'null' ? <MainPage user={user} /> : <Redirect to="/" />}</Route>
-            <Route path="/detail/:id">{user && user !== 'null' ? <DetailPage user={user} /> : <Redirect to="/" />}</Route>
+            <Route path="/detail/:id">{user && user !== 'null' ? props => <DetailPage user={user} {...props} /> : <Redirect to="/" />}</Route>
             <Route component={() => <Redirect to="/" />} />
           </Switch>
         </Wrapper>

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -6,10 +6,11 @@ import Dialog from '../Dialog/Dialog';
 import DialogCloseButton from '../DialogCloseButton/DialogCloseButton';
 
 const TeamWorkspaceView = props => {
-  const { team, subjectPDF } = props;
+  const { team, subjectPDF, onFinishedButtonClick } = props;
   const { state, openButtonProps, openButtonRef } = useToggleDialog();
 
   const handleFinishedButtonClick = () => {
+    onFinishedButtonClick?.();
     state.close();
   };
 

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -6,7 +6,7 @@ import Dialog from '../Dialog/Dialog';
 import DialogCloseButton from '../DialogCloseButton/DialogCloseButton';
 
 const TeamWorkspaceView = props => {
-  const { gitHub, notion, subjectPDF } = props;
+  const { team, subjectPDF } = props;
   const { state, openButtonProps, openButtonRef } = useToggleDialog();
 
   const handleFinishedButtonClick = () => {
@@ -21,11 +21,11 @@ const TeamWorkspaceView = props => {
         <LinkList>
           <LinkList.Title>GitHub Repository</LinkList.Title>
           <LinkList.Link>
-            <a href="https://github.com/Matching42/Matching42-front">{gitHub}</a>
+            <a href={team.gitLink}>{team.gitLink}</a>
           </LinkList.Link>
           <LinkList.Title>Notion</LinkList.Title>
           <LinkList.Link>
-            <a href="https://github.com/Matching42/Matching42-front">{notion}</a>
+            <a href={team.notionLink}>{team.notionLink}</a>
           </LinkList.Link>
           <LinkList.Title>Subject PDF</LinkList.Title>
           <LinkList.Link>
@@ -59,8 +59,6 @@ const TeamWorkspaceView = props => {
 };
 
 TeamWorkspaceView.defaultProps = {
-  gitHub: 'https://github.com/Matching42/Matching42-front',
-  notion: 'https://github.com/Matching42/Matching42-front',
   subjectPDF: 'https://github.com/Matching42/Matching42-front'
 };
 

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -18,7 +18,7 @@ const DetailPage = props => {
     return <Loading>에러 발생!</Loading>;
   }
 
-  if (getUserData.data === null || getTeamData.data === undefined) {
+  if (getUserData.data === null || getTeamData.data === null || getTeamData.data === undefined) {
     return <Loading>로딩중!</Loading>;
   }
 
@@ -32,7 +32,7 @@ const DetailPage = props => {
               <TeamMemberView team={getTeamData.data} user={getUserData.data} />
             </DetailContainer.Top>
             <DetailContainer.Bottom>
-              <TeamWorkspaceView />
+              <TeamWorkspaceView team={getTeamData.data} />
             </DetailContainer.Bottom>
           </DetailContainer.Section>
         </DetailContainer>

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -6,13 +6,23 @@ import TeamMemberView from '../components/TeamMemberView/TeamMemberView';
 import TeamProfileView from '../components/TeamProfileView/TeamProfileView';
 import TeamWorkspaceView from '../components/TeamWorkspaceView/TeamWorkspaceView';
 import { useUserData, useTeamData } from '../hooks/useUserData';
+import { api } from '../api';
 
-const DetailPage = props => {
-  const { user } = props;
+const DetailPage = ({ user, history }) => {
   const currentParams = useParams();
   const currentId = currentParams.id;
   const { getUserData } = useUserData(user);
   const { getTeamData } = useTeamData(currentId);
+
+  const handleFinishedButtonClick = async () => {
+    await api
+      .patch(`/team/${getTeamData.data?.ID}`, {
+        state: 'end'
+      })
+      .then(res => console.log(res))
+      .catch(error => console.warn(error));
+    history.push('/home');
+  };
 
   if (getUserData.error) {
     return <Loading>에러 발생!</Loading>;
@@ -32,7 +42,7 @@ const DetailPage = props => {
               <TeamMemberView team={getTeamData.data} user={getUserData.data} />
             </DetailContainer.Top>
             <DetailContainer.Bottom>
-              <TeamWorkspaceView team={getTeamData.data} />
+              <TeamWorkspaceView team={getTeamData.data} onFinishedButtonClick={handleFinishedButtonClick} />
             </DetailContainer.Bottom>
           </DetailContainer.Section>
         </DetailContainer>

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -37,7 +37,7 @@ const MainPage = props => {
     return <Loading>에러 발생!</Loading>;
   }
 
-  if (getUserData.data === null || getUserData.data === undefined || getMatchingStateData.data === undefined) {
+  if (getUserData.data === null || getUserData.data === undefined || getMatchingStateData.data === null || getMatchingStateData.data === undefined) {
     return <Loading>로딩중!</Loading>;
   }
 

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { OverlayProvider } from '@react-aria/overlays';
 import ProfileView from '../components/ProfileView/ProfileView';
@@ -16,22 +16,19 @@ const MainPage = props => {
   const { getMatchingStateData } = useStateData();
   const { teams, teamListData } = useFetchTeamListData();
 
-  const handleMatchingButtonClick = useCallback(
-    async (selectedSubject, githubId, preferredCluster) => {
-      await api
-        .post('/waitlist/', {
-          userID: user,
-          subjectName: selectedSubject,
-          gitName: githubId,
-          cluster: preferredCluster
-        })
-        .then(res => console.log(res))
-        .catch(error => console.warn(error));
-      getUserData.mutate();
-      getMatchingStateData.mutate();
-    },
-    [getUserData]
-  );
+  const handleMatchingButtonClick = async (selectedSubject, githubId, preferredCluster) => {
+    await api
+      .post('/waitlist/', {
+        userID: user,
+        subjectName: selectedSubject,
+        gitName: githubId,
+        cluster: preferredCluster
+      })
+      .then(res => console.log(res))
+      .catch(error => console.warn(error));
+    getUserData.mutate();
+    getMatchingStateData.mutate();
+  };
 
   if (getUserData.error) {
     return <Loading>에러 발생!</Loading>;


### PR DESCRIPTION
## Description
- `Team Workspace Link` 데이터를 받아와서 반영하고, 스터디 종료 버튼 클릭 시 팀이 종료(삭제)되도록 API 를 적용합니다.

### Todo
- [x] `Team Workspace Link` 데이터 GET
- [x] 스터디 종료 버튼 클릭 -> 팀 상태 변경 PATCH