### PR TITLE
팀이 종료된 상태일 때, 스터디 종료 버튼 없애고 자물쇠 비활성화 적용

### DIFF
--- a/src/components/TeamListItem/TeamListItem.js
+++ b/src/components/TeamListItem/TeamListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { TeamListItemStyled, TeamListItemBox } from './TeamListItem.styles';
+import { TeamListItemStyled, TeamListItemBox, EndText } from './TeamListItem.styles';
 import HashTag from './common/HashTag/HashTag';
 import TeamImage from './common/TeamImage/TeamImage';
 import Dday from '../Dday/Dday';
@@ -17,7 +17,7 @@ const TeamListItem = ({ teamData }) => {
           <TeamListItemBox.Subject>
             {teamData.subject} {teamData.state !== 'wait_member' && <LockIcon />}
           </TeamListItemBox.Subject>
-          <Dday mode="light" startDate={teamData.startDate} />
+          {teamData.state === 'end' ? <EndText>END</EndText> : <Dday mode="light" startDate={teamData.startDate} />}
         </TeamListItemBox>
         <TeamListItemBox>
           {/* team 데이터에 tags가 생기면 교체 예정 */}

--- a/src/components/TeamListItem/TeamListItem.styles.js
+++ b/src/components/TeamListItem/TeamListItem.styles.js
@@ -31,3 +31,9 @@ TeamListItemBox.StartDate = styled.span`
   font-weight: bold;
   color: #27babb;
 `;
+
+export const EndText = styled.span`
+  font-size: 0.7em;
+  font-weight: bold;
+  color: #bfbfbf;
+`;

--- a/src/components/TeamMemberView/TeamMemberView.js
+++ b/src/components/TeamMemberView/TeamMemberView.js
@@ -37,7 +37,7 @@ const TeamMemberView = ({ user, teamData, userDataMutate }) => {
           <TeamMemberViewTop.Title>Member</TeamMemberViewTop.Title>
           <TeamMemberViewTop.Description>현재 멤버를 모집하고 {team.state === 'wait_member' ? '있습니다.' : '있지 않습니다.'}</TeamMemberViewTop.Description>
         </TeamMemberViewTop.Wrap>
-        <TeamMemberViewTop.Lock onClick={changeTeamState} isLeader={localStorage.user === team.leaderID}>
+        <TeamMemberViewTop.Lock onClick={changeTeamState} isLeader={localStorage.user === team.leaderID} end={team.state === 'end'}>
           {team.state === 'wait_member' ? <UnlockIcon /> : <LockIcon />}
         </TeamMemberViewTop.Lock>
       </TeamMemberViewTop>

--- a/src/components/TeamMemberView/TeamMemberView.styles.js
+++ b/src/components/TeamMemberView/TeamMemberView.styles.js
@@ -36,7 +36,7 @@ TeamMemberViewTop.Description = styled.p`
 
 TeamMemberViewTop.Lock = styled.div`
   width: 23px;
-  cursor: ${props => (props.isLeader ? 'pointer' : 'Default')};
+  cursor: ${props => (props.isLeader && !props.end ? 'pointer' : 'Default')};
   margin-right: 10px;
 
   svg {
@@ -44,7 +44,7 @@ TeamMemberViewTop.Lock = styled.div`
     height: 100%;
 
     path {
-      fill: ${props => (props.isLeader ? '#27BABB' : '#D5D5D5')};
+      fill: ${props => (props.isLeader && !props.end ? '#27BABB' : '#D5D5D5')};
     }
   }
 `;

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -35,11 +35,13 @@ const TeamWorkspaceView = props => {
             <a href="https://github.com/Matching42/Matching42-front">{subjectPDF}</a>
           </LinkList.Link>
         </LinkList>
-        {user.ID === team.leaderID && (<TeamWorkspaceViewStyled.Button>
-          <TeamFinishedButton {...openButtonProps} ref={openButtonRef} onClick={forBubblingEvent}>
-            스터디 종료
-          </TeamFinishedButton>
-        </TeamWorkspaceViewStyled.Button>)}
+        {user.ID === team.leaderID && team.state !== 'end' && (
+          <TeamWorkspaceViewStyled.Button>
+            <TeamFinishedButton {...openButtonProps} ref={openButtonRef} onClick={forBubblingEvent}>
+              스터디 종료
+            </TeamFinishedButton>
+          </TeamWorkspaceViewStyled.Button>
+        )}
         <div className="scrollbar" />
       </TeamWorkspaceViewStyled>
       {state.isOpen && (

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.styles.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.styles.js
@@ -5,8 +5,9 @@ export const TeamWorkspaceViewStyled = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: flex-start;
   align-items: top;
+  position: relative;
   background-color: #fff;
   padding: 30px;
   border-radius: 20px;
@@ -35,7 +36,7 @@ TeamWorkspaceViewStyled.Title = styled.div`
   font-family: 'Noto Sans KR', sans-serif;
   font-weight: bold;
   font-size: 0.55em;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
 `;
 
 TeamWorkspaceViewStyled.Line = styled.div`
@@ -45,7 +46,7 @@ TeamWorkspaceViewStyled.Line = styled.div`
 export const LinkList = styled.div`
   width: 100%;
   overflow: auto;
-  margin-bottom: 15px;
+  margin-bottom: 20px;
   font-size: 0.75em;
 
   ::-webkit-scrollbar {
@@ -83,8 +84,9 @@ LinkList.Link = styled.div`
 `;
 
 TeamWorkspaceViewStyled.Button = styled.div`
-  display: flex;
-  justify-content: flex-end;
+  position: absolute;
+  bottom: 30px;
+  right: 30px;
 `;
 
 export const TeamFinishedButton = styled.button`


### PR DESCRIPTION
## Description
- 팀이 종료된 상태일 때, 스터디 종료 버튼을 없애고 자물쇠 버튼 또한 비활성화로 표시합니다.
- 나의 팀 목록에서도 종료된 팀은 `END` 로 표시합니다.

### Todo
- [x] 스터디 종료 버튼 감추기
- [x] 자물쇠 버튼 비활성화
- [x] 팀 목록에서 종료된 팀은 `END` 로 표시