### PR TITLE
매칭 후 깃허브 초대 다시받기 버튼 추가 & 서브젝트 PDF API 연동

### DIFF
--- a/src/components/TeamListItem/TeamListItem.js
+++ b/src/components/TeamListItem/TeamListItem.js
@@ -7,8 +7,7 @@ import Dday from '../Dday/Dday';
 import { ReactComponent as LockIcon } from '../../assets/icons/icon-teamListItemLock.svg';
 
 const TeamListItem = ({ teamData }) => {
-  const { leaderID, memberID } = teamData;
-  const member = [leaderID, ...memberID];
+  const { memberID } = teamData;
 
   return (
     <Link to={`/detail/${teamData.ID}`}>
@@ -22,7 +21,7 @@ const TeamListItem = ({ teamData }) => {
         <TeamListItemBox>
           {/* team 데이터에 tags가 생기면 교체 예정 */}
           <HashTag tags={[]} />
-          <TeamImage teamMember={member} />
+          <TeamImage teamMember={memberID} />
         </TeamListItemBox>
       </TeamListItemStyled>
     </Link>

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { OverlayContainer } from '@react-aria/overlays';
-import { TeamWorkspaceViewStyled, LinkList, TeamFinishedButton, Alert } from './TeamWorkspaceView.styles';
+import { TeamWorkspaceViewStyled, LinkList, InviteButton, TeamFinishedButton, Alert, EmptyText } from './TeamWorkspaceView.styles';
 import useToggleDialog from '../../hooks/useToggleDialog';
 import Dialog from '../Dialog/Dialog';
 import DialogCloseButton from '../DialogCloseButton/DialogCloseButton';
 
 const TeamWorkspaceView = props => {
-  const { team, user, subjectPDF, onFinishedButtonClick } = props;
+  const { team, user, onFinishedButtonClick, onInviteButtonClick } = props;
   const { state, openButtonProps, openButtonRef } = useToggleDialog();
 
   const forBubblingEvent = () => {};
@@ -16,24 +16,25 @@ const TeamWorkspaceView = props => {
     state.close();
   };
 
+  const handleInviteButtonClick = () => {
+    onInviteButtonClick();
+  };
+
   return (
     <>
       <TeamWorkspaceViewStyled className="scrollbar" user={user} team={team}>
         <TeamWorkspaceViewStyled.Title>Team Workspace Link</TeamWorkspaceViewStyled.Title>
         <TeamWorkspaceViewStyled.Line />
         <LinkList user={user} team={team}>
-          <LinkList.Title>GitHub Repository</LinkList.Title>
-          <LinkList.Link>
-            <a href={team.gitLink}>{team.gitLink}</a>
-          </LinkList.Link>
+          <LinkList.Title>
+            <span>GitHub Repository</span>
+            {team.gitLink && <InviteButton onClick={handleInviteButtonClick}>초대 받기</InviteButton>}
+          </LinkList.Title>
+          <LinkList.Link>{team.gitLink ? <a href={team.gitLink}>{team.gitLink}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
           <LinkList.Title>Notion</LinkList.Title>
-          <LinkList.Link>
-            <a href={team.notionLink}>{team.notionLink}</a>
-          </LinkList.Link>
+          <LinkList.Link>{team.notionLink ? <a href={team.notionLink}>{team.notionLink}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
           <LinkList.Title>Subject PDF</LinkList.Title>
-          <LinkList.Link>
-            <a href="https://github.com/Matching42/Matching42-front">{subjectPDF}</a>
-          </LinkList.Link>
+          <LinkList.Link>{team.subject ? <a href="https://github.com/Matching42/Matching42-front">{team.subject}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
         </LinkList>
         <div className="scrollbar" />
         {user?.ID === team?.leaderID && team.state !== 'end' && (

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -4,10 +4,12 @@ import { TeamWorkspaceViewStyled, LinkList, InviteButton, TeamFinishedButton, Al
 import useToggleDialog from '../../hooks/useToggleDialog';
 import Dialog from '../Dialog/Dialog';
 import DialogCloseButton from '../DialogCloseButton/DialogCloseButton';
+import { useTeamSubjectLink } from '../../hooks/useUserData';
 
 const TeamWorkspaceView = props => {
   const { team, user, onFinishedButtonClick, onInviteButtonClick } = props;
   const { state, openButtonProps, openButtonRef } = useToggleDialog();
+  const { getTeamSubjectLink } = useTeamSubjectLink(team?.subject);
 
   const forBubblingEvent = () => {};
 
@@ -34,7 +36,7 @@ const TeamWorkspaceView = props => {
           <LinkList.Title>Notion</LinkList.Title>
           <LinkList.Link>{team.notionLink ? <a href={team.notionLink}>{team.notionLink}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
           <LinkList.Title>Subject PDF</LinkList.Title>
-          <LinkList.Link>{team.subject ? <a href="https://github.com/Matching42/Matching42-front">{team.subject}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
+          <LinkList.Link>{team.subject ? <a href={getTeamSubjectLink?.data?.subjectPDF}>{getTeamSubjectLink?.data?.subjectPDF}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
         </LinkList>
         <div className="scrollbar" />
         {user?.ID === team?.leaderID && team.state !== 'end' && (

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.js
@@ -30,7 +30,7 @@ const TeamWorkspaceView = props => {
         <LinkList user={user} team={team}>
           <LinkList.Title>
             <span>GitHub Repository</span>
-            {team.gitLink && <InviteButton onClick={handleInviteButtonClick}>초대 받기</InviteButton>}
+            {team.memberID.find(id => id === user.ID) && team.gitLink && <InviteButton onClick={handleInviteButtonClick}>초대 받기</InviteButton>}
           </LinkList.Title>
           <LinkList.Link>{team.gitLink ? <a href={team.gitLink}>{team.gitLink}</a> : <EmptyText>링크가 존재하지 않습니다.</EmptyText>}</LinkList.Link>
           <LinkList.Title>Notion</LinkList.Title>

--- a/src/components/TeamWorkspaceView/TeamWorkspaceView.styles.js
+++ b/src/components/TeamWorkspaceView/TeamWorkspaceView.styles.js
@@ -17,7 +17,7 @@ export const TeamWorkspaceViewStyled = styled.div`
 
   .scrollbar {
     width: 4px;
-    height: ${({user, team}) => user?.ID === team?.leaderID ? 'calc(100% - 142px)' : '100%'};
+    height: ${({ user, team }) => (user?.ID === team?.leaderID ? 'calc(100% - 142px)' : '100%')};
     max-height: 210px;
     position: absolute;
     top: 60px;
@@ -56,11 +56,14 @@ export const LinkList = styled.div`
     background-color: #d5d5d5;
   }
   ::-webkit-scrollbar-track {
-    margin: 10px 0 ${({user, team}) => user?.ID === team?.leaderID ? '35px' : '10px'};
+    margin: 10px 0 ${({ user, team }) => (user?.ID === team?.leaderID ? '35px' : '10px')};
   }
 `;
 
 LinkList.Title = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   font-size: 0.75rem;
   font-weight: bold;
   margin-top: 18px;
@@ -87,7 +90,15 @@ TeamWorkspaceViewStyled.Button = styled.div`
   bottom: 30px;
   right: 30px;
   z-index: 100;
+`;
 
+export const InviteButton = styled.button`
+  color: #27babb;
+  font-size: 12px;
+  background-color: transparent;
+  margin-left: 10px;
+  padding-top: 3px;
+  cursor: pointer;
 `;
 
 export const TeamFinishedButton = styled.button`
@@ -103,7 +114,6 @@ export const TeamFinishedButton = styled.button`
   cursor: pointer;
   outline: 0;
   transition: 0.15s;
-
 
   :hover {
     background-color: #25a9aa;
@@ -142,4 +152,11 @@ Alert.Button = styled.div`
       background-color: #25a9aa;
     }
   }
+`;
+
+export const EmptyText = styled.p`
+  color: #d3d4d6;
+  font-size: 0.55em;
+  margin-left: 6px;
+  margin-top: 8px;
 `;

--- a/src/hooks/useUserData.js
+++ b/src/hooks/useUserData.js
@@ -23,3 +23,14 @@ export const useTeamData = teamID => {
 
   return { getTeamData };
 };
+
+export const useTeamSubjectLink = subject => {
+  const getTeamSubjectLink = useSWR(['getTeamSubjectLink', subject], (_, subject) =>
+    api
+      .get(`subjectPDF/${subject}`)
+      .then(res => res.data)
+      .catch(error => console.log(error))
+  );
+
+  return { getTeamSubjectLink };
+};

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -25,6 +25,19 @@ const DetailPage = ({ user, history }) => {
     history.goBack();
   };
 
+  const handleInviteButtonClick = async () => {
+    await api
+      .post(`/team/invitetorepo/${getTeamData.data?.data?.ID}/${user}`)
+      .then(res => console.log(res))
+      .catch(error => console.warn(error));
+  };
+
+  const handleTeamProfileEditButtonClick = (teamName, teamDescription, teamTags) => {
+    console.log(teamName);
+    console.log(teamDescription);
+    console.log(teamTags);
+  };
+
   if (getUserData.error) {
     return (
       <Loading>
@@ -42,12 +55,6 @@ const DetailPage = ({ user, history }) => {
     );
   }
 
-  const handleTeamProfileEditButtonClick = (teamName, teamDescription, teamTags) => {
-    console.log(teamName);
-    console.log(teamDescription);
-    console.log(teamTags);
-  };
-
   return (
     <>
       <OverlayProvider>
@@ -58,7 +65,7 @@ const DetailPage = ({ user, history }) => {
               <TeamMemberView teamData={getTeamData.data?.data} user={getUserData.data?.user} userDataMutate={getUserData.mutate} />
             </DetailContainer.Top>
             <DetailContainer.Bottom>
-              <TeamWorkspaceView team={getTeamData.data?.data} user={getUserData.data?.user} onFinishedButtonClick={handleFinishedButtonClick} />
+              <TeamWorkspaceView team={getTeamData.data?.data} user={getUserData.data?.user} onFinishedButtonClick={handleFinishedButtonClick} onInviteButtonClick={handleInviteButtonClick} />
             </DetailContainer.Bottom>
           </DetailContainer.Section>
         </DetailContainer>


### PR DESCRIPTION
## Description
- 매칭 이후, 깃허브 초대가 만료됐을 때를 고려하여 초대 다시받기 버튼을 추가합니다.
- 서브젝트 PDF API 와 연동합니다.

### Todo
- [x] 초대 다시받기 버튼 디자인
- [x] 초대 다시받기 UI 구현 및 연동
    - [x] 깃허브 링크가 있을 때 & 팀 멤버만 초대 받기 버튼이 보이도록 조건 추가
    - [x] 리더 2번 노출되는 문제 해결
- [x] 서브젝트 PDF API 연동