### PR TITLE
팀 프로필 수정 폼 에러 표시, 멤버 모집 기준 변경

### DIFF
--- a/src/components/TeamMemberView/TeamMemberView.js
+++ b/src/components/TeamMemberView/TeamMemberView.js
@@ -15,7 +15,7 @@ const TeamMemberView = ({ user, teamData, userDataMutate }) => {
 
     let changeState;
 
-    if (team.memberID.length < 3) {
+    if (team.memberID.length < 5) {
       changeState = team.state === 'less_member' ? 'wait_member' : 'less_member';
     } else {
       changeState = 'progress';

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -18,7 +18,7 @@ const DetailPage = ({ user, history }) => {
   const { getTeamData } = useTeamData(currentId);
   const { teamListData } = useFetchTeamListData();
   const [isActive, setIsActive] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleFinishedButtonClick = async () => {
     await api
@@ -105,7 +105,7 @@ const DetailPage = ({ user, history }) => {
               <TeamWorkspaceView team={getTeamData.data?.data} user={getUserData.data?.user} onFinishedButtonClick={handleFinishedButtonClick} onInviteButtonClick={handleInviteButtonClick} />
             </DetailContainer.Bottom>
           </DetailContainer.Section>
-          <Toast isActive={isActive} setIsActive={setIsActive} type="error" message={errorMessage} />
+          {isActive && <Toast setIsActive={setIsActive} type="error" message={errorMessage} />}
         </DetailContainer>
       </OverlayProvider>
     </>


### PR DESCRIPTION
팀 프로필 수정 폼에서 팀 이름, 설명이 없을 때 에러 메시지 출력되고 서버에 전송 안되게 수정
멤버 모집 기준 3 -> 5로 변경
toast 모달 동작 때만 호출되도록 변경(Main, DetailPage)

resolved:#153