### PR TITLE
Fix/#190

### DIFF
--- a/src/components/TeamProfileView/TeamProfileView.js
+++ b/src/components/TeamProfileView/TeamProfileView.js
@@ -29,8 +29,7 @@ const TeamProfileView = ({ team, user, onTeamProfileEditButtonclick }) => {
           </TeamProfileLeftBox.Title>
           <TeamDescription>{team.description ? team.description : 'Team GitHub Repository, Notion, Slack 적극 활용하여 동료들과 함께 학습을 진행해보세요!'}</TeamDescription>
           <TeamTagList>
-            <TeamTagList.Subject># {team.subject}</TeamTagList.Subject>
-            {team && team.tag ? team.tag.map((item, index) => <TeamTagList.Item key={index}># {item}</TeamTagList.Item>) : <TeamTagList.Item># 아직 등록된 태그가 없어요!</TeamTagList.Item>}
+            {team && (team.tag && team.tag.length > 0) ? team.tag.map((item, index) => <TeamTagList.Item key={index}># {item}</TeamTagList.Item>) : <TeamTagList.Item># 아직 등록된 태그가 없어요!</TeamTagList.Item>}
           </TeamTagList>
         </TeamProfileLeftBox>
         <TeamProfileRightBox>

--- a/src/components/TeamProfileView/TeamProfileView.styles.js
+++ b/src/components/TeamProfileView/TeamProfileView.styles.js
@@ -31,6 +31,7 @@ TeamProfileLeftBox.Title = styled.div`
 `;
 
 TeamProfileLeftBox.Name = styled.div`
+  overflow: hidden;
   font-size: 0.9em;
   font-weight: bold;
   margin-right: 1.8rem;


### PR DESCRIPTION
resolved: #190 

<img width="524" alt="스크린샷 2022-01-07 오후 8 04 14" src="https://user-images.githubusercontent.com/52448114/148534996-95e3548c-fa56-4dd8-a811-a88835c9549a.png">

<img width="440" alt="스크린샷 2022-01-07 오후 8 04 19" src="https://user-images.githubusercontent.com/52448114/148535002-6cee4940-d703-47ab-b15e-c29958a19139.png">


1. TeamListView와 TeamProfileView에서 태그 불일치하는 이슈 해결, 

2. TeamProfileView에서 팀 이름 길이가 너무 긴 경우 
"..."으로 뒷 부분 잘리도록 처리함 

